### PR TITLE
php 8.1 compatibility: Parameters dateType and timeType are now optional

### DIFF
--- a/IntlDateFormatter.php
+++ b/IntlDateFormatter.php
@@ -142,7 +142,7 @@ abstract class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public function __construct(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, $calendar = null, ?string $pattern = '')
+    public function __construct(?string $locale, ?int $dateType = IntlDateFormatter::FULL, ?int $timeType = IntlDateFormatter::FULL, $timezone = null, $calendar = null, ?string $pattern = '')
     {
         if ('en' !== $locale && null !== $locale) {
             throw new MethodArgumentValueNotImplementedException(__METHOD__, 'locale', $locale, 'Only the locale "en" is supported');
@@ -193,7 +193,7 @@ abstract class IntlDateFormatter
      * @throws MethodArgumentValueNotImplementedException When $locale different than "en" or null is passed
      * @throws MethodArgumentValueNotImplementedException When $calendar different than GREGORIAN is passed
      */
-    public static function create(?string $locale, ?int $dateType, ?int $timeType, $timezone = null, int $calendar = null, ?string $pattern = '')
+    public static function create(?string $locale, ?int $dateType = IntlDateFormatter::FULL, ?int $timeType = IntlDateFormatter::FULL, $timezone = null, int $calendar = null, ?string $pattern = '')
     {
         return new static($locale, $dateType, $timeType, $timezone, $calendar, $pattern);
     }


### PR DESCRIPTION
As per the [php docs](https://www.php.net/manual/en/intldateformatter.create.php), php 8.1 changed the dateType and timeType parameters to be optional.  This change should be backward compatible with < php 8.1.